### PR TITLE
Fix Vietnamese typo

### DIFF
--- a/src/app/shared/service/form-validation.service.ts
+++ b/src/app/shared/service/form-validation.service.ts
@@ -60,7 +60,7 @@ export class FormValidationService {
       const errors = control.errors?.['invalidPassword'];
       const messages: string[] = [];
       if (!errors.minLength) messages.push('Mật khẩu phải có ít nhất 9 ký tự');
-      if (!errors.hasUpperCase) messages.push('Mật khẩu pAhải có ít nhất 1 chữ cái in hoa');
+      if (!errors.hasUpperCase) messages.push('Mật khẩu phải có ít nhất 1 chữ cái in hoa');
       if (!errors.hasLowerCase) messages.push('Mật khẩu phải có ít nhất 1 chữ cái thường');
       if (!errors.hasNumber) messages.push('Mật khẩu phải có ít nhất 1 số');
       if (!errors.hasSpecialChar) messages.push('Mật khẩu phải có ít nhất 1 ký tự đặc biệt');
@@ -90,7 +90,7 @@ export class FormValidationService {
       }
       const trimmedValue = value ? value.trim() : '';
       if (options.minLength && trimmedValue.length < options.minLength) {
-        return { minLength: { message: `Dộ dài tối thiểu là ${options.minLength} ký tự` } };
+        return { minLength: { message: `Độ dài tối thiểu là ${options.minLength} ký tự` } };
       }
       if (options.maxLength && trimmedValue.length > options.maxLength) {
         return { maxLength: { message: `Độ dài tối đa là ${options.maxLength} ký tự` } };


### PR DESCRIPTION
## Summary
- fix a typo in password validation message
- correct another typo in string length error message

## Testing
- `npm test` *(fails: Test Suites: 7 failed, 4 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684100152ba0832b93f13c58fd6b319b 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR fixes typographical errors in password validation messages, correcting the uppercase letter requirement and minimum length error message. These corrections improve clarity in user feedback during form validation and maintain consistency in the application's localization.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>