### PR TITLE
fix: use styleUrls in component decorators

### DIFF
--- a/src/app/features/login-ui/login-ui.component.ts
+++ b/src/app/features/login-ui/login-ui.component.ts
@@ -20,7 +20,7 @@ import { NotificationService } from '../../shared/service/notification.service';
     selector: 'app-login-ui',
     imports: [SharedModule, NgIcon, ReactiveFormsModule, NotificationComponent],
     templateUrl: './login-ui.component.html',
-    styleUrl: './login-ui.component.scss',
+    styleUrls: ['./login-ui.component.scss'],
     viewProviders: [provideIcons({ typInfoLarge, typArrowRightThick })]
 })
 export class LoginUIComponent implements OnInit {

--- a/src/app/features/table-author/table-author.component.ts
+++ b/src/app/features/table-author/table-author.component.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
     selector: 'app-table-author',
     imports: [],
     templateUrl: './table-author.component.html',
-    styleUrl: './table-author.component.scss'
+    styleUrls: ['./table-author.component.scss']
 })
 export class TableAuthorComponent {
 

--- a/src/app/shared/components/jest-test/jest-test.component.ts
+++ b/src/app/shared/components/jest-test/jest-test.component.ts
@@ -5,7 +5,7 @@ import { SharedModule } from '../../shared.module';
     selector: 'app-jest-test',
     imports: [SharedModule],
     templateUrl: './jest-test.component.html',
-    styleUrl: './jest-test.component.scss'
+    styleUrls: ['./jest-test.component.scss']
 })
 export class JestTestComponent {
   type = `submit`;

--- a/src/app/shared/components/notification/notification.component.ts
+++ b/src/app/shared/components/notification/notification.component.ts
@@ -7,7 +7,7 @@ import { NotificationService } from '../../service/notification.service';
     selector: 'app-notification',
     imports: [SharedModule],
     templateUrl: './notification.component.html',
-    styleUrl: './notification.component.scss'
+    styleUrls: ['./notification.component.scss']
 })
 export class NotificationComponent implements OnInit {
   notifications: CustomNotification[] = [];


### PR DESCRIPTION
## Summary
- update component decorators to use `styleUrls`

## Testing
- `npm test` *(fails: 26 failed, 9 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684101493110832bb015c87197d4ff45